### PR TITLE
metadata: Fix license name (use SPDX id)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "author": "drwahl",
   "summary": "Install and configure koji, and RPM build system",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "source": "https://github.com/drwahl/puppet-koji.git",
   "project_page": "https://github.com/drwahl/puppet-koji",
   "issues_url": "https://github.com/drwahl/puppet-koji/issues",


### PR DESCRIPTION
Puppet forge recommend to use the SPDX identifier for licenses
http://spdx.org/licenses/
